### PR TITLE
feat: Removed the hardcoded HTTP scheme and port to allow the user to…

### DIFF
--- a/SharpIpp/SharpIppClient.cs
+++ b/SharpIpp/SharpIppClient.cs
@@ -64,7 +64,7 @@ namespace SharpIpp
             IIppRequestMessage ippRequest,
             CancellationToken cancellationToken = default)
         {
-            var httpPrinter = new UriBuilder(printer) { Scheme = "http", Port = printer.Port }.Uri;
+            var httpPrinter = new UriBuilder(printer).Uri;
             var httpRequest = new HttpRequestMessage(HttpMethod.Post, httpPrinter);
 
             HttpResponseMessage? response;


### PR DESCRIPTION
Removed the hardcoded HTTP scheme and port to allow the user to decide what they want to use. Currently, HTTPS URIs are changed to HTTP, which can prevent communication with the printer.

Recently experienced this on a Windows Print Server where SSL was required. Took a while to work out why the request was failing, but eventually found the scheme hardcoded in the library. Removing it allowed me to specify HTTPS in the server's address.