### PR TITLE
handle ipp/ipps explicitly

### DIFF
--- a/SharpIpp/SharpIppClient.cs
+++ b/SharpIpp/SharpIppClient.cs
@@ -64,7 +64,7 @@ namespace SharpIpp
             IIppRequestMessage ippRequest,
             CancellationToken cancellationToken = default)
         {
-            var httpPrinter = new UriBuilder(printer) { Scheme = "http", Port = printer.Port }.Uri;
+            var httpPrinter = TranslateScheme(printer);
             var httpRequest = new HttpRequestMessage(HttpMethod.Post, httpPrinter);
 
             HttpResponseMessage? response;
@@ -129,6 +129,27 @@ namespace SharpIpp
             }
 
             throw httpException;
+        }
+
+        private Uri TranslateScheme(Uri printer)
+        {
+            UriBuilder builder = new(printer);
+            if (printer.Scheme == "ipp")
+            {
+                builder.Scheme = "http";
+                if(printer.IsDefaultPort) {
+                    builder.Port = 631;
+                }
+            }
+            else if (printer.Scheme == "ipps")
+            {
+                builder.Scheme = "https";
+                if(printer.IsDefaultPort) {
+                    builder.Port = 631;
+                }
+            }
+
+            return builder.Uri;
         }
 
         public void Dispose()


### PR DESCRIPTION
closes #19

The http request scheme is currently [hard coded](https://github.com/Zelenov/SharpIpp/blob/0d5450c37508002529caf723f9af30f25e0f2037/SharpIpp/SharpIppClient.cs#L67), so using https or ipps is not currently supported.
ipp requests do not currently default to port 631.

If ipp or ipps is the scheme and a port is not provided, the port should default to 663 (and not 80/443).
- ipp: https://www.rfc-editor.org/rfc/rfc3510#section-4.2
- ipps: https://www.rfc-editor.org/rfc/rfc7472.html#section-3

This would be a breaking change for usages where
- the uri scheme is ipp, but a port is not provided and a connection on port 80 is desired
- ipps/https are specified but an insecure connection on port 80(when port is unspecified) is desired

This should solve any issues addresed by #16 but won't break usages that currently supply an ipp uri scheme.